### PR TITLE
Adicionar estilos para a página de leaderboard e outros ajustes

### DIFF
--- a/less/forum.less
+++ b/less/forum.less
@@ -44,4 +44,5 @@
 @import "forum/UserPage.less";
 @import "forum/SearchPage.less";
 @import "forum/MessagesPage.less";
+@import "forum/extensions/LeaderboardPage.less";
 @import "forum/DarkMode.less";

--- a/less/forum/DarkMode.less
+++ b/less/forum/DarkMode.less
@@ -1004,6 +1004,41 @@ body.dark-mode {
     --disc-muted:   var(--muted-color);
   }
 
+  // LeaderboardHero — dark mode (scoped to .LeaderboardPage for specificity)
+  .LeaderboardPage .LeaderboardHero::before {
+    background: linear-gradient(135deg, rgba(0,0,0,0.35) 0%, rgba(0,0,0,0.15) 60%);
+  }
+
+  // Leaderboard cards — dark surface
+  .LeaderboardPage .LeaderboardPodium-place,
+  .LeaderboardPage .LeaderboardContenders-card,
+  .LeaderboardPage .LeaderboardItem {
+    background: var(--control-bg);
+    border-color: var(--avocado-border-subtle);
+
+    &:hover {
+      background: var(--control-bg);
+    }
+  }
+
+  // Leaderboard pills + refresh
+  .LeaderboardPage .LeaderboardPage-filterBtn {
+    border-color: var(--avocado-border-chip);
+
+    &:hover {
+      background: var(--avocado-surface-1);
+      border-color: var(--avocado-border-chip);
+    }
+  }
+
+  .LeaderboardPage .LeaderboardPage-refreshBtn {
+    border-color: var(--avocado-border-chip);
+
+    &:hover {
+      background: var(--avocado-surface-1);
+    }
+  }
+
   // DiscussionHero overlay — adjust for dark backgrounds
   .DiscussionHero::before {
     background: linear-gradient(135deg, rgba(0,0,0,0.35) 0%, rgba(0,0,0,0.15) 60%);

--- a/less/forum/HomePage.less
+++ b/less/forum/HomePage.less
@@ -2167,16 +2167,16 @@
     background-repeat: no-repeat;
     height: 100%;
 
-    // Scrim layer 1: full-card gradient — strong at bottom, fades out ¾ up
+    // Scrim layer 1: full-card gradient — soft at bottom, transparent at top
     &::before {
       content: '';
       position: absolute;
       inset: 0;
       background: linear-gradient(to top,
-        rgba(0,0,0,0.90) 0%,
-        rgba(0,0,0,0.70) 25%,
-        rgba(0,0,0,0.30) 55%,
-        rgba(0,0,0,0)    75%
+        rgba(0,0,0,0.65) 0%,
+        rgba(0,0,0,0.40) 30%,
+        rgba(0,0,0,0.10) 60%,
+        rgba(0,0,0,0)    80%
       );
       z-index: 2;
       border-radius: 16px;
@@ -2235,7 +2235,7 @@
     display: flex;
     flex-direction: column;
     gap: 4px;
-    background: linear-gradient(to bottom, rgba(0,0,0,0) 0%, rgba(0,0,0,0.45) 100%);
+    background: linear-gradient(to bottom, rgba(0,0,0,0) 0%, rgba(0,0,0,0.30) 100%);
     border-radius: 0 0 16px 16px;
   }
 

--- a/less/forum/extensions/LeaderboardPage.less
+++ b/less/forum/extensions/LeaderboardPage.less
@@ -1,0 +1,179 @@
+// ── Leaderboard Extension — Avocado Design System Override ──────────────────
+// Extension: huseyinfiliz/leaderboard
+// All selectors are scoped to .LeaderboardPage so specificity (0,2,0) beats
+// the extension's own CSS (0,1,0) regardless of load order in forum.css.
+
+// ─── 1. Hero ─────────────────────────────────────────────────────────────────
+// The App.less safety net hides .Page-hero for all non-root IndexPages.
+// LeaderboardPage shares the IndexPage class, so we re-enable it explicitly.
+
+.LeaderboardPage .Page-hero {
+  display: block !important;
+}
+
+// Reset .Hero base styles (margin/max-width/border-radius) so the hero
+// spans full-width like DiscussionHero.
+.LeaderboardPage .LeaderboardHero.Hero {
+  margin: 0;
+  max-width: 100%;
+  border-radius: 0;
+}
+
+// Hero surface — matches DiscussionHero / AvocadoTagPage-hero pattern
+.LeaderboardPage .LeaderboardHero {
+  position: relative;
+  background: var(--primary-color);
+  overflow: hidden;
+
+  // Diagonal depth overlay — identical to DiscussionHero::before
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(0,0,0,0.20) 0%, rgba(0,0,0,0.04) 60%);
+    pointer-events: none;
+  }
+
+  .container {
+    position: relative;
+    z-index: 1;
+    padding: 36px 20px 40px;
+    text-align: center;
+  }
+
+  .Hero-title .icon {
+    display: block;
+    font-size: 26px;
+    margin-bottom: 10px;
+    opacity: 0.85;
+  }
+
+  .Hero-title {
+    font-size: 28px;
+    font-weight: 800;
+    letter-spacing: -0.3px;
+    color: #fff;
+    margin: 0;
+    line-height: 1.15;
+  }
+}
+
+// ─── 2. Filter pills ─────────────────────────────────────────────────────────
+
+.LeaderboardPage .LeaderboardPage-filterBtn {
+  padding: 5px 14px;
+  border-radius: @border-radius;
+  border: 1px solid var(--avocado-border-chip);
+  background: transparent;
+  color: var(--muted-color);
+  font-size: 13px;
+  font-weight: 500;
+  transition:
+    background var(--avocado-t-fast),
+    border-color var(--avocado-t-fast),
+    color var(--avocado-t-fast);
+
+  &:hover {
+    background: var(--avocado-surface-1);
+    border-color: var(--avocado-border-subtle);
+    color: var(--text-color);
+  }
+
+  &.active {
+    background: var(--primary-color);
+    border-color: var(--primary-color);
+    color: #fff;
+  }
+}
+
+// ─── 3. Refresh button ───────────────────────────────────────────────────────
+
+.LeaderboardPage .LeaderboardPage-refreshBtn {
+  border: 1px solid var(--avocado-border-chip);
+  background: transparent;
+  color: var(--avocado-muted-icon);
+  transition:
+    background var(--avocado-t-fast),
+    color var(--avocado-t-fast);
+
+  &:hover {
+    background: var(--avocado-surface-1);
+    color: var(--text-color);
+  }
+}
+
+// ─── 4. Podium cards ─────────────────────────────────────────────────────────
+
+.LeaderboardPage .LeaderboardPodium-place {
+  background: var(--body-bg);
+  border: 1px solid var(--avocado-border-subtle);
+  border-radius: @border-radius;
+  transition:
+    transform var(--avocado-t-medium),
+    box-shadow var(--avocado-t-medium);
+
+  &:hover {
+    transform: translateY(-3px);
+    box-shadow: @avocado-box-shadow;
+  }
+}
+
+.LeaderboardPage .LeaderboardPodium-place--1 { border-top: 3px solid #d4a730; }
+.LeaderboardPage .LeaderboardPodium-place--2 { border-top: 3px solid #a0a0a0; }
+.LeaderboardPage .LeaderboardPodium-place--3 { border-top: 3px solid #b87333; }
+
+.LeaderboardPage .LeaderboardPodium-stats {
+  border-top-color: var(--avocado-border-subtle);
+}
+
+// ─── 5. Top contender cards ──────────────────────────────────────────────────
+
+.LeaderboardPage .LeaderboardContenders-card {
+  background: var(--body-bg);
+  border: 1px solid var(--avocado-border-subtle);
+  border-radius: @border-radius;
+  transition:
+    transform var(--avocado-t-fast),
+    box-shadow var(--avocado-t-fast);
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: @avocado-box-shadow;
+  }
+}
+
+// ─── 6. Section titles ───────────────────────────────────────────────────────
+
+.LeaderboardPage .LeaderboardContenders-title,
+.LeaderboardPage .LeaderboardHonorable-title {
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: -0.1px;
+}
+
+// ─── 7. Honorable mention rows ───────────────────────────────────────────────
+
+.LeaderboardPage .LeaderboardItem {
+  background: var(--body-bg);
+  border: 1px solid var(--avocado-border-subtle);
+  border-radius: @border-radius;
+  transition:
+    background var(--avocado-t-fast),
+    box-shadow var(--avocado-t-fast);
+
+  &:hover {
+    background: var(--avocado-surface-1);
+    opacity: 1;
+    box-shadow: none;
+  }
+}
+
+// ─── 8. Skeleton shapes ──────────────────────────────────────────────────────
+
+.LeaderboardPage .LeaderboardSkeleton-badge,
+.LeaderboardPage .LeaderboardSkeleton-text,
+.LeaderboardPage .LeaderboardSkeleton-textSm,
+.LeaderboardPage .LeaderboardSkeleton-rank,
+.LeaderboardPage .LeaderboardSkeleton-sectionTitle {
+  border-radius: 6px;
+}


### PR DESCRIPTION
This pull request introduces Avocado Design System overrides for the Leaderboard extension, ensuring consistent styling with the rest of the forum, and refines visual treatments for both the Leaderboard and Home pages. The changes include adding a new stylesheet for the Leaderboard, updating dark mode support, and softening gradients and backgrounds for improved visual clarity.

**Leaderboard extension integration and design system overrides:**

* Added a new stylesheet, `LeaderboardPage.less`, to override and harmonize the Leaderboard extension’s styles with the Avocado Design System, covering hero section, filter pills, refresh button, podium and contender cards, section titles, honorable mentions, and skeleton loaders. All selectors are scoped for specificity.
* Imported `LeaderboardPage.less` into the main forum stylesheet to activate these overrides.

**Dark mode support for Leaderboard:**

* Added dark mode-specific styles for the Leaderboard page, including background gradients for the hero section, dark surfaces for cards, and adjusted pill and button states for better contrast and consistency.

**Visual refinements for Home page:**

* Softened the gradient overlay on Home page hero cards to be less opaque at the bottom and more transparent at the top, improving readability and aesthetics.
* Reduced the opacity of the gradient background on Home page card footers for a subtler effect.…o escuro