### PR TITLE
fix nav mobile

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "ramon/avocado",
-    "version": "2.1.18-beta",
+    "version": "2.1.19-beta",
     "description": "A modern, feature-rich Flarum theme with advanced search, real-time messaging, and comprehensive multi-language support. Built on the Avocado foundation with significant enhancements.",
     "keywords": [
         "flarum",

--- a/less/forum/App.less
+++ b/less/forum/App.less
@@ -161,18 +161,23 @@
 }
 
 // ─── Mobile: session dropdown inside App-drawer ────────────────────────────────
-// The App-drawer is position:fixed with overflow-y:auto which clips absolutely-
-// positioned Dropdown-menus. Make them expand inline so they are always visible.
+// Mirrors Flarum v2 core's approach exactly:
+// Make every control in Header-controls fill the full drawer width so that the
+// Dropdown-menu (position:absolute; right:0) aligns to the drawer's right edge
+// instead of overflowing outside it.
+// Reset width:auto on buttons *inside* the open menu so they don't stretch to 100%.
 @media @phone {
-  .App-drawer .open > .Dropdown-menu {
-    position: static !important;
-    transform: none !important;
-    box-shadow: none !important;
-    border: 1px solid var(--avocado-border-subtle);
-    border-radius: 10px;
-    width: 100%;
-    margin-top: 4px;
-    animation: none !important;
+  .App-drawer .Header-controls {
+    .FormControl, .ButtonGroup, .Button {
+      width: 100%;
+      justify-content: start;
+    }
+    .Dropdown-menu {
+      .ButtonGroup, .Button {
+        width: auto;
+        justify-content: initial;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
This pull request updates the Avocado theme for Flarum with a version bump and improvements to the mobile session dropdown in the app drawer. The main focus is aligning the dropdown’s behavior with Flarum v2 core for better mobile usability.

**Mobile app drawer dropdown improvements:**
- Updated the `.App-drawer .Header-controls` styles on mobile to make all controls (such as `.FormControl`, `.ButtonGroup`, `.Button`) fill the full drawer width, ensuring dropdown menus align with the right edge of the drawer and do not overflow.
- Reset the width and alignment for buttons inside open dropdown menus so they do not stretch to 100% width, preserving proper layout inside the menu.

**Version update:**
- Bumped the package version in `composer.json` from `2.1.18-beta` to `2.1.19-beta`.… layout styling