### PR TITLE
ci: bump pinned action SHAs (closes Dependabot #110, #111, #112, #113)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
         run: composer update --no-interaction --no-progress --prefer-dist --no-scripts
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: 20
           cache: 'npm'
@@ -163,7 +163,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Dependency Review
-        uses: actions/dependency-review-action@3b139cfc5fae8b618d3eae3675e383bb1769c019  # v4.5.0
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294  # v5.0.0
         with:
           fail-on-severity: high
           comment-summary-in-pr: on-failure

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -62,7 +62,7 @@ jobs:
           extensions: bcmath, ctype, curl, dom, fileinfo, gd, intl, mbstring, mysqlnd, openssl, pdo, pdo_mysql, tokenizer, xml, zip
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: 20
           cache: 'npm'
@@ -171,19 +171,21 @@ jobs:
 
       - name: Subir artefato com resultados (PR)
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b  # v4.5.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: lhci-pr-${{ github.event.pull_request.number }}
           path: /tmp/lhci-out
           retention-days: 14
+          overwrite: true
 
       - name: Subir artefato com resultados (master baseline)
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b  # v4.5.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: lhci-master
           path: /tmp/lhci-out
           retention-days: 90
+          overwrite: true
 
   compare:
     name: Comparar PR vs master
@@ -199,7 +201,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: 20
 

--- a/.github/workflows/release-management.yml
+++ b/.github/workflows/release-management.yml
@@ -35,7 +35,7 @@ jobs:
           fetch-depth: 0
 
       - name: Configurar Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: 20
           cache: 'npm'
@@ -72,7 +72,7 @@ jobs:
       # §35.13 R4 — provenance assinada (SLSA) para os artefatos do release.
       - name: Atestar provenance dos artefatos
         if: steps.check_version.outputs.changed == 'true' && steps.create_release.outcome == 'success'
-        uses: actions/attest-build-provenance@520d128f165991a6c774bcb264f323e3d70747f4  # v2.2.0
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4.1.0
         with:
           subject-path: |
             composer.json


### PR DESCRIPTION
Aplica em lote os 4 PRs do Dependabot, mantendo o padrão de pinning por SHA completo (CLAUDE.md §35.13 C2/C3).

- actions/setup-node            v4.4.0 → v6.4.0   (#110, 4 ocorrências)
- actions/upload-artifact       v4.5.0 → v7.0.1   (#111, 2 ocorrências)
- actions/attest-build-provenance v2.2.0 → v4.1.0 (#112)
- actions/dependency-review-action v4.5.0 → v5.0.0 (#113)

upload-artifact v5+ tornou artefatos imutáveis por nome; adiciona `overwrite: true` nos 2 uploads do performance.yml (lhci-pr-*, lhci-master) para permitir re-runs na mesma PR ou no mesmo commit de master.