### PR TITLE
ci(security): roave/security-advisories como gate duro de CVE

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
         "flarum/tags": "^2.0.0",
         "phpunit/phpunit": "^11.5 || ^13.2.0",
         "mockery/mockery": "^1.6",
-        "phpstan/phpstan": "^2.2"
+        "phpstan/phpstan": "^2.2",
+        "roave/security-advisories": "dev-latest"
     },
     "scripts": {
         "test": "phpunit",


### PR DESCRIPTION
## Objetivo

Replica no avocado o reforço já aplicado no marketplace (PR ram0ng1/marketplace#61): **`roave/security-advisories:dev-latest` em `require-dev`** como gate duro de CVE.

## Como funciona

O pacote não instala código — ele declara `conflict` com toda versão de dependência que tenha advisory publicado. Qualquer `composer update`/`composer require` (local ou na CI, que resolve as dependências a cada run) passa a **falhar na resolução** em vez de instalar versão vulnerável.

## Verificação local

```
composer require --dev roave/security-advisories:dev-latest
# → instala limpo
# → "No security vulnerability advisories found."
```

Complementa o `composer audit` do ci.yml: o audit reporta o que JÁ está na árvore; o roave impede que a versão vulnerável entre.

https://claude.ai/code/session_01PE7xfyEdL8Q2j9hz5Xn77m

---
_Generated by [Claude Code](https://claude.ai/code/session_01PE7xfyEdL8Q2j9hz5Xn77m)_